### PR TITLE
修复未指定特殊 token 时，未按词典合并分词的问题

### DIFF
--- a/bpe.py
+++ b/bpe.py
@@ -105,6 +105,10 @@ class BPETokenizer:
         # 特殊token分离
         pattern='('+'|'.join([re.escape(tok) for tok in self.sp_s2i])+')'
         splits=re.split(pattern,text)
+
+        # 未指定特殊token时
+        if len(self.sp_s2i) == 0:
+            splits = [text]
         
         # 编码结果
         enc_ids=[]


### PR DESCRIPTION
修复前：

1. 未指定特殊 token
<img width="1032" alt="image" src="https://github.com/owenliang/bpe-tokenizer/assets/1460411/eff1c74b-dc61-47c7-ae57-9ff72e5c6ad6">

2. 指定特殊 token 
<img width="1112" alt="image" src="https://github.com/owenliang/bpe-tokenizer/assets/1460411/539c0ad0-eed0-4288-88d5-370aa81e2965">

修复后：

1. 未指定特殊 token
<img width="956" alt="image" src="https://github.com/owenliang/bpe-tokenizer/assets/1460411/e6419f09-b9a0-4f57-9074-4758c2f53680">


3. 指定特殊 token 

<img width="899" alt="image" src="https://github.com/owenliang/bpe-tokenizer/assets/1460411/929b64cc-3b6f-487e-817e-5845047fdb7c">
